### PR TITLE
update the spotify green

### DIFF
--- a/src/simple-icons.json
+++ b/src/simple-icons.json
@@ -917,7 +917,7 @@
         },
         {
             "title": "Spotify",
-            "hex": "84BD00",
+            "hex": "1ED760",
             "source": "https://developer.spotify.com/design"
         },
         {


### PR DESCRIPTION
sampled from the press logos provided at https://press.spotify.com/us/images.  sadly no svg update available yet