### PR TITLE
Update Ubuntu brand colour

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1362,7 +1362,7 @@
         },
         {
             "title": "Ubuntu",
-            "hex": "DD4814",
+            "hex": "E95420",
             "source": "https://insights.ubuntu.com/press-centre"
         },
         {


### PR DESCRIPTION
Ubuntu's brand colour changed from #DD4814 to #E95420. This can be found on the Ubuntu design sites colour palette:
https://design.ubuntu.com/brand/colour-palette